### PR TITLE
fix: modify remove_filtered_policy method to support filtering of empty strings

### DIFF
--- a/casbin_pymongo_adapter/adapter.py
+++ b/casbin_pymongo_adapter/adapter.py
@@ -165,7 +165,7 @@ class Adapter(persist.Adapter):
         if not (1 <= field_index + len(field_values) <= 6):
             return False
         query = {
-            f"v{index + field_index}": value for index, value in enumerate(field_values)
+            f"v{index + field_index}": value for index, value in enumerate(field_values) if value != ""
         }
         query["ptype"] = ptype
         results = self._collection.delete_many(query)

--- a/casbin_pymongo_adapter/adapter.py
+++ b/casbin_pymongo_adapter/adapter.py
@@ -165,7 +165,9 @@ class Adapter(persist.Adapter):
         if not (1 <= field_index + len(field_values) <= 6):
             return False
         query = {
-            f"v{index + field_index}": value for index, value in enumerate(field_values) if value != ""
+            f"v{index + field_index}": value 
+            for index, value in enumerate(field_values) 
+            if value != ""
         }
         query["ptype"] = ptype
         results = self._collection.delete_many(query)

--- a/casbin_pymongo_adapter/adapter.py
+++ b/casbin_pymongo_adapter/adapter.py
@@ -165,8 +165,8 @@ class Adapter(persist.Adapter):
         if not (1 <= field_index + len(field_values) <= 6):
             return False
         query = {
-            f"v{index + field_index}": value 
-            for index, value in enumerate(field_values) 
+            f"v{index + field_index}": value
+            for index, value in enumerate(field_values)
             if value != ""
         }
         query["ptype"] = ptype


### PR DESCRIPTION
Modify remove_filtered_policy method to support filtering of empty strings

such as
`enforcer.remove_filtered_policy(0, "alice", "", "read") # The obj can be an empty string representing any`

And I looked at the official documentation and other SDKs (e.g. golang version)
![image](https://github.com/user-attachments/assets/c79c1677-ea9b-4aac-b6ac-f1d1b3c4f85d)
